### PR TITLE
update import for aqt.modelchooser

### DIFF
--- a/addons21/ImportVideo/gui/importor.py
+++ b/addons21/ImportVideo/gui/importor.py
@@ -38,7 +38,7 @@ import os.path
 import anki
 import aqt
 import aqt.models
-from aqt import mw
+from aqt import mw, modelchooser
 from aqt.qt import *
 from aqt.studydeck import StudyDeck
 from anki.hooks import addHook, remHook, runHook


### PR DESCRIPTION
Just fixing the error I got on first launch with line 567 
self.modelChooser = aqt.modelchooser.ModelChooser(mw, modes)

"AttributeError: module 'aqt' has no attribute 'modelchooser'"